### PR TITLE
+ Singular version of Prefix/Midfix, tweaked output for missing license files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate-license-file": "bin/generate-license-file"
   },
   "scripts": {
-    "clean": "trash dist",
+    "clean": "rm -rf ./dist",
     "build": "npm run clean&&npm run build:pipeline",
     "build:pipeline": "tsc",
     "start": "npm run build&&generate-license-file",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,10 @@ import * as fs from "fs";
 import * as os from "os";
 
 const BULLET: string = " - ";
-const PREFIX: string = "The following NPM packages may be included in this product:" + os.EOL + os.EOL;
-const MIDFIX: string = os.EOL + "These packages each contain the following license and notice below:" + os.EOL + os.EOL;
+const PREFIX: string = "The following NPM package may be included in this product:" + os.EOL + os.EOL;
+const PREFIX_PLURAL: string = "The following NPM packages may be included in this product:" + os.EOL + os.EOL;
+const MIDFIX: string = os.EOL + "This package contains the following license and notice below:" + os.EOL + os.EOL;
+const MIDFIX_PLURAL: string = os.EOL + "These packages each contain the following license and notice below:" + os.EOL + os.EOL;
 const SUFFIX: string = os.EOL + os.EOL + "-----------" + os.EOL + os.EOL;
 const FOOTER: string = "This file was generated with generate-license-file! https://www.npmjs.com/package/generate-license-file";
 
@@ -29,7 +31,8 @@ export async function generateLicenseFile(path: string, outputPath: string): Pro
 
   stream.once("open", () => {
     for (const license of licenses) {
-      stream.write(PREFIX);
+      const hasMultipleDeps: boolean = license.dependencies.length > 1;
+      stream.write(hasMultipleDeps ? PREFIX_PLURAL : PREFIX);
 
       for (const dep of license.dependencies) {
         stream.write(BULLET);
@@ -37,7 +40,7 @@ export async function generateLicenseFile(path: string, outputPath: string): Pro
         stream.write(os.EOL);
       }
 
-      stream.write(MIDFIX);
+      stream.write(hasMultipleDeps ? MIDFIX_PLURAL : MIDFIX);
 
       stream.write(license.content.trim());
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,8 +73,7 @@ export async function getProjectLicenses(path: string): Promise<ILicense[]> {
       if (dependencyValue.licenseFile) {
         let license: string = "";
 
-        // Make sure only real license files are read
-        if (nodePath.basename(dependencyValue.licenseFile!).match(/license|licence|copyright/i)) {
+        if (fs.existsSync(dependencyValue.licenseFile)) {
           license = await readFileAsync(
             dependencyValue.licenseFile,
             { encoding: UTF8 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,7 @@ export async function getProjectLicenses(path: string): Promise<ILicense[]> {
         let license: string = "";
 
         // Make sure only real license files are read
-        if (nodePath.basename(dependencyValue.licenseFile!).match(/license|copyright/i)) {
+        if (nodePath.basename(dependencyValue.licenseFile!).match(/license|licence|copyright/i)) {
           license = await readFileAsync(
             dependencyValue.licenseFile,
             { encoding: UTF8 }


### PR DESCRIPTION
fixes #1 
The pull request introduces a test for most-surely valid license files by looking at the filenames. On every negative result, the `license` field from `package.json` is used. Although the output is not comparable to those with proper license files, as there is no other text than the abbreviated version of the license, this is still better than including a potentially large `README.md` file.

fixes #2 
The pull request introduces a check for dependency lists with only one item. The CLI will then output a version of `PREFIX`and `MIDFIX` which address the package in singular form.